### PR TITLE
Fix pyproject.toml and add note for aiohttp

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Download the latest plugin file from [Releases](https://github.com/MipaSenpai/Mi
 
 **For LeviLamina**: You need to have [LeviStone](https://github.com/LiteLDev/LeviStone) installed.
 
+> [!NOTE]
+> The plugin requires `aiohttp` to be installed in your Python environment! You can install it with:
+> `pip install aiohttp`
+
 ---
 
 ### Step 2️⃣: Launch the Web Server

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Download the latest plugin file from [Releases](https://github.com/MipaSenpai/Mi
 **For LeviLamina**: You need to have [LeviStone](https://github.com/LiteLDev/LeviStone) installed.
 
 > [!NOTE]
-> The plugin requires `aiohttp` to be installed in your Python environment! You can install it with:
+> The plugin may require `aiohttp` to be installed in your Python environment! You can install it with:
 > `pip install aiohttp`
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,16 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "endstone-mipmap"
-version = "1.0.3"
-
+version = "1.0.4"
 dependencies = ["aiohttp>=3.13.0"]
-
 authors = [
     { name = "Mipa" },
     { name = "Bebrowskiy" },
 ]
 
-description = "MipMap - Interactive Online Map for Endstone & LeviLamina.
+description = "MipMap - Interactive Online Map for Endstone & LeviLamina."
 readme = "README.md"
 license = { file = "LICENSE" }
 keywords = ["endstone", "plugin", "online-map"]


### PR DESCRIPTION
The plugin fails to load on certain environments because `aiohttp` isn’t installed, despite it's in the dependencies field of the `pyproject.toml`.

I'm unsure why, but on Windows, this doesn't seem to happen.

The previous `pyproject.toml` also lacked a closing quotation mark, which made plugin load fail.